### PR TITLE
Update addremove.asciidoc

### DIFF
--- a/doc/fr_FR/addremove.asciidoc
+++ b/doc/fr_FR/addremove.asciidoc
@@ -31,7 +31,7 @@ openzwave ainsi que le mapping de commandes Jeedom.
 Lors d'une inclusion, il est conseillé que le module soit à proximité du contrôleur principal, soit à moins d'un mètre de la box.
 
 [TIP]
-Certains modules requièrent une inclusion en mode sécurisé, par exemple pour les serrures de porte. L’inclusion sécurisée doit être lancé via
+Certains modules requièrent une inclusion en mode sécurisé, par exemple pour les serrures de porte. L’inclusion sécurisée doit être lancée via
 l’onglet Actions de la Vue *Réseau Z-Wave*.
 image:../images/openzwave41.png[]
 


### PR DESCRIPTION
Bonjour, une petite faute.

[TIP] : J'ai pas compris, pourquoi parler d'exclusion après inclusion puis d'exclusion avant inclusion ?
Un module n'a pas besoin d'être exclu par le même contrôleur sur lequel il a été préalablement inclu. D'où le fait qu'on recommande d'exécuter une exclusion avant chaque inclusion.

Merci
